### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.4'
 if needs_sphinx > sphinx.__display_version__:
-    message = 'This project needs at least Sphinx v%s' % needs_sphinx
+    message = 'This project needs at least Sphinx v{0!s}'.format(needs_sphinx)
     raise VersionRequirementError(message)
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/pygem/filehandler.py
+++ b/pygem/filehandler.py
@@ -48,7 +48,7 @@ class FileHandler(object):
 		__, file_ext = os.path.splitext(filename)
 		if not file_ext in self.extension:
 			raise ValueError('The input file does not have the proper extension. \
-				It is %s, instead of %s.' % (file_ext, self.extension))
+				It is {0!s}, instead of {1!s}.'.format(file_ext, self.extension))
 
 
 	def _check_filename_type(self, filename):
@@ -58,7 +58,7 @@ class FileHandler(object):
 		:param string filename: file to check.
 		"""
 		if not isinstance(filename, basestring):
-			raise TypeError('The given filename (%s) must be a string' % filename)
+			raise TypeError('The given filename ({0!s}) must be a string'.format(filename))
 
 
 	def _check_infile_instantiation(self, infile):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mathLab:PyGeM?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mathLab:PyGeM?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)