### PR TITLE
Fix latex equations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,6 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
 ]
 


### PR DESCRIPTION
This commit provides a quick fix to #232. I removed the line `sphinx.ext.imgmath`, since it looks like the project isn's using any of the additional functionalities provided by this extension.