### PR TITLE
Fix latex equations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,6 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
 ]
 


### PR DESCRIPTION
This commit fixes #232 by removing the Sphinx extension `sphinx.ext.imgmath`. It looks like the documentation is not using any of the additional features provided by this extension.