### PR TITLE
Modify sphinx-build.yml to run the corresponding action when a tag is created

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,9 +1,10 @@
 name: "Deploy Documentation"
 
-on: 
+on:
   push:
-    tags:
-      - "*"
+    tags: [ '**' ]
+  release:
+    types: [ 'created' ]
 
 jobs:
   docs:


### PR DESCRIPTION
After @ndem0 release the newest tag some minutes ago the action `sphinx-build` wasn't triggered, I proposed a fix I found on another repository with a similar version tagging schema.