### PR TITLE
Fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The official distribution is on GitHub, and you can clone the repository using
 To install the package just type:
 
 ```bash
-> python setup.py install
+> python install .
 ```
 
 To uninstall the package you have to rerun the installation and record the installed files in order to remove them:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The official distribution is on GitHub, and you can clone the repository using
 To install the package just type:
 
 ```bash
-> python install .
+> pip install .
 ```
 
 To uninstall the package you have to rerun the installation and record the installed files in order to remove them:


### PR DESCRIPTION
Changes the line "python setup.py install" in the installation instructions, which is deprecated. 
Fixes #297.